### PR TITLE
Add basic first-person horror framework

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -2,6 +2,7 @@
 
 [/Script/EngineSettings.GameMapsSettings]
 GameDefaultMap=/Engine/Maps/Templates/OpenWorld
+GameModeClass=/Script/Horror.HorrorGameMode
 
 [/Script/Engine.RendererSettings]
 r.AllowStaticLighting=False

--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -82,3 +82,12 @@ DefaultTouchInterface=/Engine/MobileResources/HUD/DefaultVirtualJoysticks.Defaul
 -ConsoleKeys=Tilde
 +ConsoleKeys=Tilde
 
+; Player movement mappings
+AxisMappings=(AxisName="MoveForward",Scale=1.0,Key=W)
+AxisMappings=(AxisName="MoveForward",Scale=-1.0,Key=S)
+AxisMappings=(AxisName="MoveRight",Scale=1.0,Key=D)
+AxisMappings=(AxisName="MoveRight",Scale=-1.0,Key=A)
+AxisMappings=(AxisName="Turn",Scale=1.0,Key=MouseX)
+AxisMappings=(AxisName="LookUp",Scale=-1.0,Key=MouseY)
+ActionMappings=(ActionName="Hide",Key=E)
+

--- a/Source/Horror/Game/HorrorGameMode.cpp
+++ b/Source/Horror/Game/HorrorGameMode.cpp
@@ -1,0 +1,11 @@
+#include "Game/HorrorGameMode.h"
+#include "Player/HorrorPlayerCharacter.h"
+#include "HUD/MenuHUD.h"
+#include "UObject/ConstructorHelpers.h"
+
+AHorrorGameMode::AHorrorGameMode()
+{
+    static ConstructorHelpers::FClassFinder<APawn> PlayerPawnClassFinder(TEXT("/Script/Horror.HorrorPlayerCharacter"));
+    DefaultPawnClass = PlayerPawnClassFinder.Class;
+    HUDClass = AMenuHUD::StaticClass();
+}

--- a/Source/Horror/Game/HorrorGameMode.h
+++ b/Source/Horror/Game/HorrorGameMode.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "HorrorGameMode.generated.h"
+
+UCLASS()
+class AHorrorGameMode : public AGameModeBase
+{
+    GENERATED_BODY()
+
+public:
+    AHorrorGameMode();
+};

--- a/Source/Horror/HUD/MenuHUD.cpp
+++ b/Source/Horror/HUD/MenuHUD.cpp
@@ -1,0 +1,17 @@
+#include "HUD/MenuHUD.h"
+#include "UI/MenuWidget.h"
+#include "Blueprint/UserWidget.h"
+
+void AMenuHUD::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (MenuClass)
+    {
+        UMenuWidget* Menu = CreateWidget<UMenuWidget>(GetWorld(), MenuClass);
+        if (Menu)
+        {
+            Menu->AddToViewport();
+        }
+    }
+}

--- a/Source/Horror/HUD/MenuHUD.h
+++ b/Source/Horror/HUD/MenuHUD.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/HUD.h"
+#include "MenuHUD.generated.h"
+
+class UMenuWidget;
+
+UCLASS()
+class AMenuHUD : public AHUD
+{
+    GENERATED_BODY()
+
+public:
+    virtual void BeginPlay() override;
+
+protected:
+    UPROPERTY(EditDefaultsOnly, Category="UI")
+    TSubclassOf<UMenuWidget> MenuClass;
+};

--- a/Source/Horror/Horror.Build.cs
+++ b/Source/Horror/Horror.Build.cs
@@ -8,7 +8,16 @@ public class Horror : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput" });
+                PublicDependencyModuleNames.AddRange(new string[]
+                {
+                        "Core",
+                        "CoreUObject",
+                        "Engine",
+                        "InputCore",
+                        "EnhancedInput",
+                        "AIModule",
+                        "UMG"
+                });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 

--- a/Source/Horror/Interactables/HidingSpot.cpp
+++ b/Source/Horror/Interactables/HidingSpot.cpp
@@ -1,0 +1,8 @@
+#include "Interactables/HidingSpot.h"
+#include "Components/BoxComponent.h"
+
+AHidingSpot::AHidingSpot()
+{
+    BoxComp = CreateDefaultSubobject<UBoxComponent>(TEXT("Box"));
+    RootComponent = BoxComp;
+}

--- a/Source/Horror/Interactables/HidingSpot.h
+++ b/Source/Horror/Interactables/HidingSpot.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "HidingSpot.generated.h"
+
+UCLASS()
+class AHidingSpot : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AHidingSpot();
+
+    UPROPERTY(VisibleAnywhere)
+    class UBoxComponent* BoxComp;
+};

--- a/Source/Horror/Monster/HorrorMonsterCharacter.cpp
+++ b/Source/Horror/Monster/HorrorMonsterCharacter.cpp
@@ -1,0 +1,33 @@
+#include "Monster/HorrorMonsterCharacter.h"
+#include "Perception/PawnSensingComponent.h"
+#include "Player/HorrorPlayerCharacter.h"
+#include "Kismet/GameplayStatics.h"
+
+AHorrorMonsterCharacter::AHorrorMonsterCharacter()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    PawnSensingComp = CreateDefaultSubobject<UPawnSensingComponent>(TEXT("PawnSensing"));
+    PawnSensingComp->SightRadius = 1000.f;
+    PawnSensingComp->SetPeripheralVisionAngle(60.f);
+}
+
+void AHorrorMonsterCharacter::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (PawnSensingComp)
+    {
+        PawnSensingComp->OnSeePawn.AddDynamic(this, &AHorrorMonsterCharacter::OnSeePawn);
+    }
+}
+
+void AHorrorMonsterCharacter::OnSeePawn(APawn* Pawn)
+{
+    AHorrorPlayerCharacter* Player = Cast<AHorrorPlayerCharacter>(Pawn);
+    if (Player && !Player->IsHiddenFromMonster())
+    {
+        UGameplayStatics::PlaySoundAtLocation(this, nullptr, GetActorLocation());
+        // TODO: Add chasing behavior here
+    }
+}

--- a/Source/Horror/Monster/HorrorMonsterCharacter.h
+++ b/Source/Horror/Monster/HorrorMonsterCharacter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Character.h"
+#include "HorrorMonsterCharacter.generated.h"
+
+class UPawnSensingComponent;
+
+UCLASS()
+class AHorrorMonsterCharacter : public ACharacter
+{
+    GENERATED_BODY()
+
+public:
+    AHorrorMonsterCharacter();
+
+protected:
+    virtual void BeginPlay() override;
+
+    UPROPERTY(VisibleAnywhere)
+    UPawnSensingComponent* PawnSensingComp;
+
+    UFUNCTION()
+    void OnSeePawn(APawn* Pawn);
+};

--- a/Source/Horror/Player/HorrorPlayerCharacter.cpp
+++ b/Source/Horror/Player/HorrorPlayerCharacter.cpp
@@ -1,0 +1,75 @@
+#include "Player/HorrorPlayerCharacter.h"
+#include "Camera/CameraComponent.h"
+#include "Components/InputComponent.h"
+
+AHorrorPlayerCharacter::AHorrorPlayerCharacter()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    CameraComp = CreateDefaultSubobject<UCameraComponent>(TEXT("FirstPersonCamera"));
+    CameraComp->SetupAttachment(GetCapsuleComponent());
+    CameraComp->bUsePawnControlRotation = true;
+
+    bIsHidden = false;
+}
+
+void AHorrorPlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
+{
+    check(PlayerInputComponent);
+
+    PlayerInputComponent->BindAxis("MoveForward", this, &AHorrorPlayerCharacter::MoveForward);
+    PlayerInputComponent->BindAxis("MoveRight", this, &AHorrorPlayerCharacter::MoveRight);
+    PlayerInputComponent->BindAxis("Turn", this, &AHorrorPlayerCharacter::Turn);
+    PlayerInputComponent->BindAxis("LookUp", this, &AHorrorPlayerCharacter::LookUp);
+    PlayerInputComponent->BindAction("Hide", IE_Pressed, this, &AHorrorPlayerCharacter::ToggleHide);
+}
+
+void AHorrorPlayerCharacter::MoveForward(float Value)
+{
+    if (Value != 0.f)
+    {
+        AddMovementInput(GetActorForwardVector(), Value);
+    }
+}
+
+void AHorrorPlayerCharacter::MoveRight(float Value)
+{
+    if (Value != 0.f)
+    {
+        AddMovementInput(GetActorRightVector(), Value);
+    }
+}
+
+void AHorrorPlayerCharacter::Turn(float Value)
+{
+    AddControllerYawInput(Value);
+}
+
+void AHorrorPlayerCharacter::LookUp(float Value)
+{
+    AddControllerPitchInput(Value);
+}
+
+void AHorrorPlayerCharacter::StartHide()
+{
+    bIsHidden = true;
+    SetActorHiddenInGame(true);
+}
+
+void AHorrorPlayerCharacter::StopHide()
+{
+    bIsHidden = false;
+    SetActorHiddenInGame(false);
+}
+
+void AHorrorPlayerCharacter::ToggleHide()
+{
+    if (bIsHidden)
+    {
+        StopHide();
+    }
+    else
+    {
+        StartHide();
+    }
+}

--- a/Source/Horror/Player/HorrorPlayerCharacter.h
+++ b/Source/Horror/Player/HorrorPlayerCharacter.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Character.h"
+#include "HorrorPlayerCharacter.generated.h"
+
+UCLASS()
+class AHorrorPlayerCharacter : public ACharacter
+{
+    GENERATED_BODY()
+
+public:
+    AHorrorPlayerCharacter();
+
+    virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
+
+    /** Returns true if player is currently hiding */
+    bool IsHiddenFromMonster() const { return bIsHidden; }
+
+    /** Start hiding in a hiding spot */
+    void StartHide();
+
+    /** Stop hiding */
+    void StopHide();
+
+    /** Toggle hiding when the hide action is triggered */
+    void ToggleHide();
+
+protected:
+    /** First person camera */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+    class UCameraComponent* CameraComp;
+
+    /** Whether the player is hiding */
+    bool bIsHidden;
+
+    void MoveForward(float Value);
+    void MoveRight(float Value);
+    void Turn(float Value);
+    void LookUp(float Value);
+};

--- a/Source/Horror/UI/MenuWidget.h
+++ b/Source/Horror/UI/MenuWidget.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "MenuWidget.generated.h"
+
+UCLASS()
+class UMenuWidget : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION(BlueprintImplementableEvent)
+    void OnStartGame();
+};


### PR DESCRIPTION
## Summary
- update build script with AI and UI modules
- configure default game mode
- add input mappings
- implement first-person player character with hiding mechanic
- create monster character using pawn sensing
- set up basic game mode and HUD with placeholder menu widget
- add hiding spot actor

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a23be119c8333b9660e917c02f820