### PR TITLE
Enable proper player yaw rotation

### DIFF
--- a/Source/Horror/Private/Player/HorrorPlayerCharacter.cpp
+++ b/Source/Horror/Private/Player/HorrorPlayerCharacter.cpp
@@ -2,6 +2,7 @@
 #include "Camera/CameraComponent.h"
 #include "Components/InputComponent.h"
 #include "Components/CapsuleComponent.h"
+#include "GameFramework/CharacterMovementComponent.h"
 
 AHorrorPlayerCharacter::AHorrorPlayerCharacter()
 {
@@ -10,6 +11,10 @@ AHorrorPlayerCharacter::AHorrorPlayerCharacter()
     CameraComp = CreateDefaultSubobject<UCameraComponent>(TEXT("FirstPersonCamera"));
     CameraComp->SetupAttachment(GetCapsuleComponent());
     CameraComp->bUsePawnControlRotation = true;
+
+    bUseControllerRotationYaw = true;
+    bUseControllerRotationPitch = true;
+    GetCharacterMovement()->bOrientRotationToMovement = false;
 
     bIsHidden = false;
 }


### PR DESCRIPTION
## Summary
- ensure the player character rotates with the controller
- disable orientation to movement so X-axis mouse input turns the camera and character

## Testing
- `UnrealBuildTool --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b05afedac833395b6a605bec5dd9c